### PR TITLE
Feat 기존 loader에서 호출하는 스케쥴링 형식 변경, bojData변수를 전역에서 내부로 변경

### DIFF
--- a/css/inject.css
+++ b/css/inject.css
@@ -1,0 +1,29 @@
+.BaekjoonHub_progress {
+    display: inline-block; 
+    pointer-events: none; 
+    width: 0.8em; 
+    height: 0.8em; 
+    border: 0.4em solid transparent; 
+    border-color: #eee; 
+    border-top-color: #3E67EC; 
+    border-radius: 50%; 
+    animation: loadingspin 1.0s linear infinite; 
+} @keyframes loadingspin { 100% { transform: rotate(360deg) }}
+
+#BaekjoonHub_progress_elem.markuploadfailed {
+    display: inline-block;
+    transform: rotate(45deg);
+    height:13px;
+    width:5px;
+    border-bottom:3px solid red;
+    border-right:3px solid red;
+}
+
+#BaekjoonHub_progress_elem.markuploaded{
+    display: inline-block;
+    transform: rotate(45deg);
+    height:13px;
+    width:5px;
+    border-bottom:3px solid #78b13f;
+    border-right:3px solid #78b13f;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,9 @@
         "https://www.acmicpc.net/status*",
         "https://github.com/*"
       ],
+      "css": [
+        "css/inject.css"
+      ],
       "js": [
         "scripts/baekjoon/variables.js",
         "scripts/baekjoon/keyfunctions.js",

--- a/scripts/baekjoon/UpdateForNewVersion.js
+++ b/scripts/baekjoon/UpdateForNewVersion.js
@@ -3,37 +3,34 @@
   버전마다 내용이 다르며 버전이 다를 때만 사용되어야합니다.
 */
 
-function insertUpdateButton(){
-    let elem = document.getElementById('BaekjoonHub_update_element');
-    if (elem !== undefined) {
-      elem = document.createElement('span');
-      elem.id = 'BaekjoonHub_update_element';
-      elem.className = 'runcode-wrapper__8rXm';
-      elem.style = 'margin-left: 10px;padding-top: 0px;';
-    }
+function insertUpdateButton() {
+  let elem = document.getElementById('BaekjoonHub_update_element');
+  if (elem !== undefined) {
+    elem = document.createElement('span');
+    elem.id = 'BaekjoonHub_update_element';
+    elem.className = 'runcode-wrapper__8rXm';
+    elem.style = 'margin-left: 10px;padding-top: 0px;';
+  }
 
-    let button = document.createElement('button');
-    button.className = 'BaekjoonHub_update';
-    button.id = 'BaekjoonHub_update_elem';
-    button.innerHTML = '업데이트 실행';
-    button.onclick = updateAlert;
-    elem.append(button);
-    
-    const target = document.getElementById('status-table').childNodes[1].childNodes[0].childNodes[3];
-    if (target.childNodes.length > 0) {
-      target.childNodes[0].append(elem);
-    }
+  const button = document.createElement('button');
+  button.className = 'BaekjoonHub_update';
+  button.id = 'BaekjoonHub_update_elem';
+  button.innerHTML = '업데이트 실행';
+  button.onclick = updateAlert;
+  elem.append(button);
+
+  const target = document.getElementById('status-table').childNodes[1].childNodes[0].childNodes[3];
+  if (target.childNodes.length > 0) {
+    target.childNodes[0].append(elem);
+  }
 }
 
-function updateAlert(){
-    console.log("click");
-    if(confirm("업데이트 사항을 확인하였습니다")){
-        updateLocalStorage();
-    };
+function updateAlert() {
+  console.log('click');
+  if (confirm('업데이트 사항을 확인하였습니다')) {
+    updateLocalStorage();
+  }
 }
-
 
 /* 추후 개발 예정 */
-function updateLocalStorage(){
-    
-}
+function updateLocalStorage() {}

--- a/scripts/baekjoon/keyfunctions.js
+++ b/scripts/baekjoon/keyfunctions.js
@@ -7,7 +7,7 @@
     type: CommitType의 readme or code
     cb: Callback 함수(업로드 후 로딩 아이콘 처리를 맡는다
 */
-function uploadGit(code, directory, fileName, type, cb = undefined) {
+function uploadGit(code, directory, fileName, type, cb = undefined, bojData) {
   /* Get necessary payload data */
   chrome.storage.local.get('BaekjoonHub_token', (t) => {
     const token = t.BaekjoonHub_token;
@@ -29,7 +29,7 @@ function uploadGit(code, directory, fileName, type, cb = undefined) {
                   sha = stats.submission[filePath][type];
                 }
 
-                upload(token, hook, code, directory, fileName, type, sha, cb);
+                upload(token, hook, code, directory, fileName, type, sha, cb, bojData);
               });
             }
           });
@@ -51,7 +51,7 @@ function uploadGit(code, directory, fileName, type, cb = undefined) {
     sha: 현재 업로드된 파일의 SHA
     cb: Callback 함수(업로드 후 로딩 아이콘 처리를 맡는다
 */
-const upload = (token, hook, code, directory, filename, type, sha, cb = undefined) => {
+function upload(token, hook, code, directory, filename, type, sha, cb = undefined, bojData) {
   // To validate user, load user object from GitHub.
 
   fetch(`https://api.github.com/repos/${hook}/contents/${directory}/${filename}`, {
@@ -61,8 +61,8 @@ const upload = (token, hook, code, directory, filename, type, sha, cb = undefine
   })
     .then((res) => res.json())
     .then((data) => {
-      if (debug && type == CommitType.readme) console.log('data', data);
-      if (data != null && (data != data.content) != null && data.content.sha != null && data.content.sha != undefined) {
+      if (debug && type === CommitType.readme) console.log('data', data);
+      if (data != null && (data !== data.content) != null && data.content.sha != null && data.content.sha !== undefined) {
         const { sha } = data.content; // get updated SHA.
         chrome.storage.local.get('stats', (data) => {
           let { stats } = data;
@@ -93,4 +93,4 @@ const upload = (token, hook, code, directory, filename, type, sha, cb = undefine
         });
       }
     });
-};
+}

--- a/scripts/baekjoon/parsing.js
+++ b/scripts/baekjoon/parsing.js
@@ -3,15 +3,100 @@
   모든 해당 파일의 모든 함수는 findData()를 통해 호출됩니다.
 */
 
-
 /*
   bojData를 초기화하는 함수로 문제 요약과 코드를 파싱합니다.
-*/
-function findData() {
-  
-  findFromResultTable();
-  findWithPromise();
 
+  - 문제 설명: problemDescription
+  - Github repo에 저장될 디렉토리: directory
+  - 커밋 메시지: message 
+  - 백준 문제 카테고리: category
+  - 파일명: fileName
+  - Readme 내용 : readme
+*/
+async function findData() {
+  const bojData = {
+    // Meta data of problem
+    meta: {
+      title: '',
+      problemId: '',
+      level: '',
+      problemDescription: '',
+      language: '',
+      message: '',
+      fileName: '',
+      category: '',
+      readme: '',
+      directory: '',
+    },
+    submission: {
+      submissionId: '',
+      code: '',
+      memory: '',
+      runtime: '',
+    },
+  };
+
+  try {
+    const { 
+      username, 
+      result, 
+      memory, 
+      runtime, 
+      language, 
+      submissionTime, 
+      submissionId, 
+      problemId 
+    } = findFromResultTable();
+    const {
+      title, 
+      level, 
+      code,
+      tags,
+      problem_description, 
+      problem_input, 
+      problem_output 
+    } = await findProblemDetailsAndSubmissionCode(problemId, submissionId);
+    const problemDescription = `### 문제 설명\n\n${problem_description}\n\n`
+                            + `### 입력 \n\n ${problem_input}\n\n`
+                            + `### 출력 \n\n ${problem_output}\n\n`;
+    const directory = `백준/${level.replace(/ .*/, '')}/${problemId}.${title.replace(/\s+/g, '-').replace(titleRegex, '')}`;
+    const message = `[${level}] Title: ${title}, Time: ${runtime} ms, Memory: ${memory} KB -BaekjoonHub`;
+    const tagl = [];
+    tags.forEach((tag) => tagl.push(`${categories[tag.key]}(${tag.key})`));
+    const category = tagl.join(', ');
+    const fileName = title.replace(/\s+/g, '-').replace(titleRegex, '') + languages[language];
+    const readme = `# [${level}] ${title} - ${problemId} \n\n` 
+                + `[문제 링크](https://www.acmicpc.net/problem/${problemId}) \n\n`
+                + `### 성능 요약\n\n`
+                + `메모리: ${memory} KB, `
+                + `시간: ${runtime} ms\n\n`
+                + `### 분류\n\n`
+                + `${category}\n\n`
+                + `${problemDescription}\n\n`;
+    return {
+      meta: {
+        title,
+        problemId,
+        level,
+        problemDescription,
+        language,
+        message,
+        fileName,
+        category,
+        readme,
+        directory,
+      },
+      submission: {
+        submissionId,
+        code,
+        memory,
+        runtime,
+      },
+    };
+  } catch (error) {
+    console.error(error);
+  }
+  return bojData;
 }
 
 function findUsername() {
@@ -21,8 +106,6 @@ function findUsername() {
 function isExistResultTable() {
   return document.getElementById('status-table') !== null;
 }
-
-
 
 function findResultTableList() {
   const table = document.getElementById('status-table');
@@ -43,6 +126,7 @@ function findResultTableList() {
       }
     });
     const obj = {};
+    obj.element = row;
     for (let j = 0; j < headers.length; j++) {
       obj[headers[j]] = cells[j];
     }
@@ -52,103 +136,76 @@ function findResultTableList() {
   return list;
 }
 
-
 /*
   제출 화면의 데이터를 파싱하는 함수로 다음 데이터를 확인합니다.
-
-    - 메모리: bojData.submission.memory
-    - 실행시간: bojData.submission.runtime
-    - 언어: bojData.meta.language
-    - 제출번호: bojData.submission.submissionId
-    - 문제번호: bojData.meta.problemId
-
+    - 유저이름: username
+    - 실행결과: result
+    - 메모리: memory
+    - 실행시간: runtime
+    - 제출언어: language
+    - 제출시간: submissionTime
+    - 제출번호: submissionId
+    - 문제번호: problemId
+    - 해당html요소 : element
 */
 function findFromResultTable() {
-  if (isExistResultTable()) {
-    const resultList = findResultTableList();
-    if (resultList.length === 0) return;
-    const row = resultList[0];
-    if (row.username !== findUsername()) {
-      if (debug) console.log('Username does not match', row.username, findUsername());
-      return;
-    }
-    bojData.submission.memory = row.memory;
-    bojData.submission.runtime = row.runtime;
-    bojData.submission.submissionId = row.submissionId;
-    bojData.meta.language = row.language;
-    bojData.meta.problemId = row.problemId;
-  } else if (debug) console.log('Result table not found');
+  if (!isExistResultTable()) {
+    if (debug) console.log('Result table not found');
+  }
+  const resultList = findResultTableList();
+  if (resultList.length === 0) return;
+  const row = resultList[0];
+  return row;
 }
-
 
 /*
   Fetch를 사용하여 정보를 구하는 함수로 다음 정보를 확인합니다.
 
-    - 문제 설명: bojData.meta.problemDescription
-    - 제출 코드: bojData.submission.code
-    - 문제 제목: bojData.meta.title
-    - 문제 등급: bojData.meta.level 
-    - Github repo에 저장될 디렉토리: bojData.meta.directory
-    - 커밋 메시지: bojData.meta.message 
-    - 백준 문제 카테고리: bojData.meta.category
-    - 파일명: bojData.meta.fileName
-    - Readme 내용 : bojData.meta.readme
-
+    - 문제 설명: problem_description
+    - 문제 입력값: problem_input
+    - 문제 출력값: problem_output
+    - 제출 코드: code
+    - 문제 제목: title
+    - 문제 등급: level 
+    - Github repo에 저장될 디렉토리: directory
+    - 커밋 메시지: message 
+    - 백준 문제 카테고리: category
 */
-function findWithPromise() {
+
+async function findProblemDetailsAndSubmissionCode(problemId, submissionId) {
   if (debug) console.log('in find with promise');
-  if (checkElem(bojData.meta.problemId) && checkElem(bojData.submission.submissionId)) {
-    const DescriptionParse = fetch(`https://www.acmicpc.net/problem/${bojData.meta.problemId}`, { method: 'GET' });
-    const CodeParse = fetch(`https://www.acmicpc.net/source/download/${bojData.submission.submissionId}`, { method: 'GET' });
-    const SolvedAPI = fetch(`https://solved.ac/api/v3/problem/show?problemId=${bojData.meta.problemId}`, { method: 'GET' });
-    Promise.all([DescriptionParse, CodeParse, SolvedAPI])
+  if (checkElem(problemId) && checkElem(submissionId)) {
+    const DescriptionParse = fetch(`https://www.acmicpc.net/problem/${problemId}`, { method: 'GET' });
+    const CodeParse = fetch(`https://www.acmicpc.net/source/download/${submissionId}`, { method: 'GET' });
+    const SolvedAPI = fetch(`https://solved.ac/api/v3/problem/show?problemId=${problemId}`, { method: 'GET' });
+    return Promise.all([DescriptionParse, CodeParse, SolvedAPI])
       .then(([despResponse, codeResponse, solvedResponse]) => Promise.all([despResponse.text(), codeResponse.text(), solvedResponse.json()]))
       .then(([descriptionText, codeText, solvedJson]) => {
         /* Get Question Description */
-        let questionDescription = '';
         const parser = new DOMParser();
         const doc = parser.parseFromString(descriptionText, 'text/html');
+        let problem_description;
+        let problem_input;
+        let problem_output;
         if (doc != null) {
-          questionDescription = `### 문제 설명\n\n${unescapeHtml(doc.getElementById('problem_description').innerHTML.trim())}\n\n`
-                              + `### 입력 \n\n ${unescapeHtml(doc.getElementById('problem_input').innerHTML.trim())}\n\n`
-                              + `### 출력 \n\n ${unescapeHtml(doc.getElementById('problem_output').innerHTML.trim())}\n\n`;
+          problem_description = `${unescapeHtml(doc.getElementById('problem_description').innerHTML.trim())}`;
+          problem_input =       `${unescapeHtml(doc.getElementById('problem_input').innerHTML.trim())}`;
+          problem_output =      `${unescapeHtml(doc.getElementById('problem_output').innerHTML.trim())}`;
         }
-        bojData.meta.problemDescription = questionDescription;
-        if (debug) console.log('findWithPromise - description', questionDescription);
         /* Get Code */
-        bojData.submission.code = codeText;
-        if (debug) console.log('findWithPromise - code', codeText);
+        const code = codeText;
+        if (debug) console.log('findWithPromise - code', code);
         /* Get Solved Response */
-        bojData.meta.title = solvedJson.titleKo;
-        bojData.meta.level = bj_level[solvedJson.level];
-        bojData.meta.directory = `백준/${bojData.meta.level.replace(/ .*/, '')}/${bojData.meta.problemId}.${bojData.meta.title.replace(/\s+/g, '-').replace(titleRegex, '')}`;
-        bojData.meta.message = `[${bojData.meta.level}] Title: ${bojData.meta.title}, Time: ${bojData.submission.runtime} ms, Memory: ${bojData.submission.memory} KB -BaekjoonHub`;
-        let str = '';
-        solvedJson.tags.forEach((tag) => (str += `${categories[tag.key]}(${tag.key}), `));
-        if (debug) console.log(str.length);
-        const { length } = str;
-        bojData.meta.category = str.substring(0, length - 2);
-        if (debug) console.log('findWithPromise - leveldoc', solvedJson);
-        /* 파일명 */
-        bojData.meta.fileName = bojData.meta.title.replace(/\s+/g, '-').replace(titleRegex, '') + languages[bojData.meta.language];
-        /* Create Readme */
-        bojData.meta.readme = `# [${bojData.meta.level}] ${bojData.meta.title} - ${bojData.meta.problemId} \n\n` 
-                            + `[문제 링크](https://www.acmicpc.net/problem/${bojData.meta.problemId}) \n\n`
-                            + `### 성능 요약\n\n`
-                            + `메모리: ${bojData.submission.memory} KB, `
-                            + `시간: ${bojData.submission.runtime} ms\n\n`
-                            + `### 분류\n\n`
-                            + `${bojData.meta.category}\n\n`
-                            + `${bojData.meta.problemDescription}\n\n`;
-
-        if (debug) console.log('findData', bojData);
-        beginUpload();
-      })
-      .catch((err) => {
-        console.log('error ocurred: ', err);
-        uploadState.uploading = false;
-        markUploadFailed();
+        const { tags } = solvedJson;
+        const title = solvedJson.titleKo;
+        const level = bj_level[solvedJson.level];
+        return { problemId, submissionId, title, level, tags, code, problem_description, problem_input, problem_output };
       });
+    // .catch((err) => {
+    //   console.log('error ocurred: ', err);
+    //   uploadState.uploading = false;
+    //   markUploadFailedCSS();
+    // });
   }
 }
 
@@ -160,7 +217,7 @@ function startUploadCountDown() {
     if (uploadState.uploading === true) {
       // still uploading, then it failed
       uploadState.uploading = false;
-      markUploadFailed();
+      markUploadFailedCSS();
     }
   }, 10000);
 }

--- a/scripts/baekjoon/util.js
+++ b/scripts/baekjoon/util.js
@@ -19,53 +19,20 @@ function startUpload() {
 
 // Upload icon - Set Completed Icon
 /* This will create a tick mark before "Run Code" button signalling BaekjoonHub has done its job */
-function markUploaded() {
-  if (uploadState.countdown) clearTimeout(uploadState.countdown);
-  delete uploadState.countdown;
-  uploadState.uploading = false;
+function markUploadedCSS() {
   const elem = document.getElementById('BaekjoonHub_progress_elem');
-  elem.className = '';
-  const style = 'display: inline-block;transform: rotate(45deg);height:13px;width:5px;border-bottom:3px solid #78b13f;border-right:3px solid #78b13f;';
-  elem.style = style;
+  elem.className = 'markuploaded';
 }
 
 // Upload icon - Set Failed Icon
 /* This will create a failed tick mark before "Run Code" button signalling that upload failed */
-function markUploadFailed() {
-  if (uploadState.uploading === true) uploadState.uploading = false;
+function markUploadFailedCSS() {
   const elem = document.getElementById('BaekjoonHub_progress_elem');
-  elem.className = '';
-  const style = 'display: inline-block;transform: rotate(45deg);height:13px;width:5px;border-bottom:3px solid red;border-right:3px solid red;';
-  elem.style = style;
+  elem.className = 'markuploadfailed';
 }
 
-/* Since we dont yet have callbacks/promises that helps to find out if things went bad */
-/* we will start 10 seconds counter and even after that upload is not complete, then we conclude its failed */
-function startUploadCountDown() {
-  uploadState.uploading = true;
-  uploadState.countdown = setTimeout(() => {
-    if (uploadState.uploading === true) {
-      // still uploading, then it failed
-      uploadState.uploading = false;
-      markUploadFailed();
-    }
-  }, 10000);
-}
-
-/* inject css style required for the upload progress feature */
-function injectStyle() {
-  const style = document.createElement('style');
-  style.textContent = '.BaekjoonHub_progress {\
-    display: inline-block; \
-    pointer-events: none; \
-    width: 0.8em; \
-    height: 0.8em; \
-    border: 0.4em solid transparent; \
-    border-color: #eee; \
-    border-top-color: #3E67EC; \
-    border-radius: 50%; \
-    animation: loadingspin 1.0s linear infinite; } @keyframes loadingspin { 100% { transform: rotate(360deg) }}';
-  document.head.append(style);
+function getVersion() {
+  return chrome.runtime.getManifest().version;
 }
 
 /* Util function to check if an element exists */
@@ -84,13 +51,6 @@ function isNotEmpty(obj) {
     }
   }
   return true;
-}
-
-function ready() {
-  if (debug) {
-    console.log('ready', bojData);
-  }
-  return isNotEmpty(bojData);
 }
 
 function escapeHtml(text) {

--- a/scripts/baekjoon/variables.js
+++ b/scripts/baekjoon/variables.js
@@ -340,24 +340,3 @@ const titleRegex = new RegExp('[^a-zA-Z0-9가-힣 -]', 'i');
 
 /* state of upload for progress */
 const uploadState = { uploading: false };
-const bojData = {
-  // Meta data of problem
-  meta: {
-    title: '',
-    problemId: '',
-    level: '',
-    problemDescription: '',
-    language: '',
-    message: '',
-    fileName: '',
-    category: '',
-    readme: '',
-    directory: '',
-  },
-  submission: {
-    submissionId: '',
-    code: '',
-    memory: '',
-    runtime: '',
-  },
-};


### PR DESCRIPTION
- Refactor injectCSS 부분을 제거하고, inject.css 스타일 파일을 즉시 적용으로 변경
- Style UpdateForNewVersion에 대한 포멧을 prettier에 맞게 조정
- Feat loader를 호출하고 종료하는 startLoader, stopLoader 함수 생성
- Feat bojData 변수를 전역에서 내부로 구조 변경
- Refactor findData, findFromResultTable, findWithPromise의 처리 로직을 함수형으로 변경하고, 파싱된 값의 표현 처리를 findData가 처리하도록 변경
- Rename 함수 이름 변경 findWithPromise -> findProblemDetailsAndSubmissionCode, markUploaded -> markUploadedCSS, markUploadFailed -> markUploadFailedCSS
- Fix uploadGit 및 upload 함수에 bojData 입력 파라미터로 넘기도록 임의 수정 (*TODO: 변경이 필요함)