### PR TITLE
Fix 반환값이 빈 배열일 시에 처리 로직 추가

### DIFF
--- a/scripts/baekjoon/baekjoon.js
+++ b/scripts/baekjoon/baekjoon.js
@@ -16,7 +16,9 @@ else if(currentUrl.includes('.net/user')){
 function startLoader() {
   loader = setInterval(async () => {
     if (isExistResultTable()) {
-      const { username, result } = findFromResultTable();
+      const table = findFromResultTable();
+      if (isNull(table) || table.length === 0) return;
+      const { username, result } = table;
       if (username !== findUsername() || result === '틀렸습니다') {
         stopLoader();
         return;


### PR DESCRIPTION
TypeError: Cannot destructure property 'username' of 'findFromResultTable(...)' as it is undefined.